### PR TITLE
docs: Fix usage example for 'tree' command in README

### DIFF
--- a/tools/estimate_danger/README.md
+++ b/tools/estimate_danger/README.md
@@ -237,7 +237,7 @@ Nothing except progress bars.
 ### Usage
 
 ```sh
-go run ./tools/estimate_danger tree [-o <OUTPUT_FILEPATH>] [-min_gap PERCENTAGE] <PATH/TO/INPUT_FILE>
+go run ./tools/estimate_danger tree [-o <OUTPUT_FILEPATH>] [-min_gap <PERCENTAGE>] <PATH/TO/INPUT_FILE>
 ```
 
 ### What It Does


### PR DESCRIPTION
オプション引数のプレースホルダに <> を付け忘れていたので追記する。