### PR TITLE
feat: Replace panic() with error in getMetricsInternal()

### DIFF
--- a/internal/ai/metrics.go
+++ b/internal/ai/metrics.go
@@ -196,7 +196,10 @@ func (a *ManueAI) getMetricsInternal(
 		if p.ID() == playerID {
 			continue
 		}
-		d := a.getRandomHoraScoreChangesDist(state, playerID, &p)
+		d, err := a.getRandomHoraScoreChangesDist(state, playerID, &p)
+		if err != nil {
+			return nil, err
+		}
 		scoreChangesDistsOnOtherHora = append(scoreChangesDistsOnOtherHora, d)
 	}
 

--- a/internal/ai/metrics.go
+++ b/internal/ai/metrics.go
@@ -175,7 +175,10 @@ func (a *ManueAI) getMetricsInternal(
 	if err != nil {
 		return nil, err
 	}
-	immediateScoreChangesDists := a.getImmediateScoreChangesDists(state, playerID, dahaiCandidates)
+	immediateScoreChangesDists, err := a.getImmediateScoreChangesDists(state, playerID, dahaiCandidates)
+	if err != nil {
+		return nil, err
+	}
 	ms, err := a.getHoraEstimation(state, playerID, dahaiCandidates, shanten, goals, tehais, furos, reach)
 	if err != nil {
 		return nil, err

--- a/internal/ai/prob_dist.go
+++ b/internal/ai/prob_dist.go
@@ -327,7 +327,7 @@ func (a *ManueAI) getRandomHoraScoreChangesDist(
 	state game.StateViewer,
 	playerID int,
 	actor *base.Player,
-) *core.VectorProbDist {
+) (*core.VectorProbDist, error) {
 	var horaPointsFreqs map[string]int
 	if actor.ID() == state.Oya().ID() {
 		horaPointsFreqs = a.stats.OyaHoraPointsFreqs
@@ -343,7 +343,7 @@ func (a *ManueAI) getRandomHoraScoreChangesDist(
 		}
 		p, err := strconv.ParseFloat(points, 64)
 		if err != nil {
-			panic("Invalid stats file: failed to convert key of horaPointsFreqs to float64 (" + points + ").")
+			return nil, fmt.Errorf("invalid stats file: failed to convert key of horaPointsFreqs to float64 (%s)", points)
 		}
 		f := float64(freq) / totalFreqs
 		hm.Set(p, f)
@@ -351,7 +351,7 @@ func (a *ManueAI) getRandomHoraScoreChangesDist(
 
 	horaPointsDist := core.NewScalarProbDist(hm)
 	horaFactorsDist := a.getHoraFactorsDist(state, playerID, actor)
-	return core.MultScalarVector(horaPointsDist, horaFactorsDist)
+	return core.MultScalarVector(horaPointsDist, horaFactorsDist), nil
 }
 
 func (a *ManueAI) getHoraFactorsDist(

--- a/internal/ai/prob_dist.go
+++ b/internal/ai/prob_dist.go
@@ -233,7 +233,7 @@ func (a *ManueAI) getImmediateScoreChangesDists(
 	state game.StateViewer,
 	playerID int,
 	dahaiCandidates []base.Pai,
-) map[string]*core.VectorProbDist {
+) (map[string]*core.VectorProbDist, error) {
 	scoreChangesDists := make(map[string]*core.VectorProbDist, len(dahaiCandidates))
 	for _, pai := range dahaiCandidates {
 		var key string
@@ -255,7 +255,7 @@ func (a *ManueAI) getImmediateScoreChangesDists(
 
 		scene, err := estimator.NewScene(state, &me, &horaPlayer)
 		if err != nil {
-			panic(err)
+			return nil, fmt.Errorf("an error occurred in getImmediateScoreChangesDists: %w", err)
 		}
 
 		tenpaiProb := a.tenpaiProbEstimator.Estimate(&horaPlayer, state)
@@ -274,7 +274,7 @@ func (a *ManueAI) getImmediateScoreChangesDists(
 			}
 			p, err := strconv.ParseFloat(points, 64)
 			if err != nil {
-				panic("Invalid stats file: failed to convert key of horaPointsFreqs to float64 (" + points + ").")
+				return nil, fmt.Errorf("invalid stats file: failed to convert key of horaPointsFreqs to float64 (%s)", points)
 			}
 			f := float64(freq) / totalFreqs
 			hm.Set(p, f)
@@ -292,7 +292,7 @@ func (a *ManueAI) getImmediateScoreChangesDists(
 			key := pai.ToString()
 			isAnpai, err := scene.Evaluate("anpai", &pai)
 			if err != nil {
-				panic(err)
+				return nil, fmt.Errorf("an error occurred in getImmediateScoreChangesDists: %w", err)
 			}
 
 			var hojuProb float64
@@ -301,7 +301,7 @@ func (a *ManueAI) getImmediateScoreChangesDists(
 			} else {
 				probInfo, err := a.dangerEstimator.EstimateProb(scene, &pai)
 				if err != nil {
-					panic(err)
+					return nil, fmt.Errorf("an error occurred in getImmediateScoreChangesDists: %w", err)
 				}
 				hojuProb = tenpaiProb * probInfo.Prob
 			}
@@ -316,7 +316,7 @@ func (a *ManueAI) getImmediateScoreChangesDists(
 		}
 	}
 
-	return scoreChangesDists
+	return scoreChangesDists, nil
 }
 
 func (a *ManueAI) getRyukyokuProbOnMyNoHora(state game.StateViewer) float64 {


### PR DESCRIPTION
getMetricsInternal() 内で呼び出している

- getImmediateScoreChangesDists()
- getRandomHoraScoreChangesDist()

内の panic() を error を返すように変更する