### PR TITLE
refactor: Match variable names to type names

### DIFF
--- a/test/original_vs_port/compare/main.go
+++ b/test/original_vs_port/compare/main.go
@@ -154,24 +154,24 @@ func run(args []string, w io.Writer) error {
 	if err != nil {
 		log.Fatalf("failed to create AI: %v", err)
 	}
-	verifier := NewComparer(ai)
+	comparer := NewComparer(ai)
 
 	archive := shared.NewArchive(paths, &mjai.MjaiAdapter{})
 	var prevLog string
 	separator := strings.Repeat("=", 122)
 
 	onAction := func(action inbound.Event) error {
-		action, err := verifier.ModifyAction(action, archive.StateAnalyzer())
+		action, err := comparer.ModifyAction(action, archive.StateAnalyzer())
 		if err != nil {
 			return err
 		}
-		if err := verifier.MakeDecision(archive.StateAnalyzer()); err != nil {
+		if err := comparer.MakeDecision(archive.StateAnalyzer()); err != nil {
 			return err
 		}
 		if err := archive.StateUpdater().Update(action); err != nil {
 			return err
 		}
-		detail, err := verifier.CompareAction(action, archive.StateViewer())
+		detail, err := comparer.CompareAction(action, archive.StateViewer())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
型名を変更した際に変数名を合わせて変更するのを忘れていたため、変数名も型名に合わせる