### PR TITLE
chore: Specify 3.12 as the Python version in devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -19,5 +19,5 @@ sudo apt-get clean
 sudo rm -rf /var/lib/apt/lists/*
 
 export UV_LINK_MODE=copy
-uv venv --clear
+uv venv --python 3.12 --clear
 uv pip install mjai


### PR DESCRIPTION
mjai.app は 3.12 までしかバイナリの wheel をアップロードしていないが、
devcontainer の デフォルトの Python バージョンが 3.13 のためインストールに失敗する。

対策として uv venv での仮想環境作成時に Python バージョンを 3.12 に指定する。